### PR TITLE
638 Restore OneTrust cookie check

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,5 +1,5 @@
 // check if an active campaign is running or OneTrust needs scan the active scripts
-export const COOKIE_CHECK = true;
+export const COOKIE_CHECK = false;
 
 // ONE TRUST COOKIE CONSENT
 export const DATA_DOMAIN_SCRIPT = '18961cc8-1604-4bea-8e69-a5e7879e56c5';


### PR DESCRIPTION
# Update

Restore the OneTrust cookie check after a successful backend script scan

#

Fix [638](https://github.com/hlxsites/vg-macktrucks-com/issues/638)

Test URLs:
- Before: https://main--vg-macktrucks-hn--hlxsites.hlx.page/
- After: https://638-enable-script-check--vg-macktrucks-hn--hlxsites.hlx.page/
